### PR TITLE
Elixir 1.15+: Fix call to Kernel.self/0

### DIFF
--- a/lib/delayed_server.ex
+++ b/lib/delayed_server.ex
@@ -29,7 +29,7 @@ defmodule DelayedServer do
 
   def delayed_death(reason, state) do
     lifetime = :erlang.system_time(:milli_seconds) - state.started
-    Process.send_after(self, {:die, reason, lifetime}, max(state.delay - lifetime, 0))
+    Process.send_after(self(), {:die, reason, lifetime}, max(state.delay - lifetime, 0))
     %{state| pid: nil}
   end
 


### PR DESCRIPTION
See https://github.com/elixir-lang/elixir/blob/v1.15/CHANGELOG.md#elixir-6

> [Kernel] Raise instead of warning on undefined variables. Previously, an undefined variable would attempt to invoke a function of the same name, which led to confusing error messages, especially to newcomers. To enable the previous behaviour, invoke Code.compiler_options(on_undefined_variable: :warn) at the top of your mix.exs